### PR TITLE
Support double legacy color codes

### DIFF
--- a/src/main/java/de/themoep/minedown/MineDownParser.java
+++ b/src/main/java/de/themoep/minedown/MineDownParser.java
@@ -171,7 +171,9 @@ public class MineDownParser {
                     if (c1 == c) {
                         try {
                             encoded = parseColor(colorString.toString(), "", lenient());
-                            i = j;
+                            if(j - 1 > i) {
+                                i = j;
+                            }
                         } catch (IllegalArgumentException ignored) {
                         }
                         break;


### PR DESCRIPTION
With the change of valueOf to parseColor in parsing strings with multiple color codes don't parse correctly (e.g. &e&ltest got parsed to a yellow text "ltest")