### PR TITLE
Fix build failed

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <dependency>
             <groupId>net.md-5</groupId>
             <artifactId>bungeecord-chat</artifactId>
-            <version>1.16-R0.4-SNAPSHOT</version>
+            <version>1.16-R0.4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
1.16-R0.4-SNAPSHOT does not exist on bungee repo anymore, use 1.16-R0.4 instead.