### PR TITLE
Fix stringifier copy

### DIFF
--- a/src/main/java/de/themoep/minedown/adventure/MineDownStringifier.java
+++ b/src/main/java/de/themoep/minedown/adventure/MineDownStringifier.java
@@ -314,14 +314,13 @@ public class MineDownStringifier {
      * @return This stringifier's instance
      */
     public MineDownStringifier copy(MineDownStringifier from) {
-        MineDownStringifier copy = new MineDownStringifier();
         useLegacyColors(from.useLegacyColors());
         useLegacyFormatting(from.useLegacyFormatting());
         preferSimpleEvents(from.preferSimpleEvents());
         formattingInEventDefinition(from.formattingInEventDefinition());
         colorInEventDefinition(from.colorInEventDefinition());
         colorChar(from.colorChar());
-        return copy;
+        return this;
     }
 
     /**


### PR DESCRIPTION
The stringifier's setting was not correctly copied. The method would always create a new stringifier and return it with default settings.